### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,6 @@
 name: DartZone
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/06luki06/DartZone/security/code-scanning/1](https://github.com/06luki06/DartZone/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the job only checks out code and interacts with external services (SonarCloud), it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
